### PR TITLE
Implement earnings winners ML pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ backtest/  - strategy evaluation utilities
    ```
 
 Raw JSON files will be saved in `data/raw/`.
+
+### Full pipeline example
+
+After fetching the Nasdaq calendar JSON, run the entire process:
+
+```bash
+python run_pipeline.py \
+    --start 2018-01-01 --end 2025-05-31 \
+    --calendar_json calendar_20250610.json \
+    --top 5 --retrain
+```
+
+This builds/updates the dataset, trains the CatBoost model on GPU and prints the top candidates for the next session.

--- a/earnings/build_dataset.py
+++ b/earnings/build_dataset.py
@@ -1,0 +1,156 @@
+import argparse
+from datetime import datetime, timedelta
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from tqdm import tqdm
+
+
+OUT_PATH = Path("data/earnings_dataset.parquet")
+CHUNK_SIZE = 2000
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build earnings events dataset")
+    p.add_argument("--start", required=True, type=str, help="start date YYYY-MM-DD")
+    p.add_argument("--end", required=True, type=str, help="end date YYYY-MM-DD")
+    p.add_argument("--force", action="store_true", help="rebuild even if file exists")
+    return p.parse_args()
+
+
+def get_universe() -> list:
+    tickers = set(yf.tickers_sp500() + yf.tickers_sp400() + yf.tickers_sp600())
+    return sorted(tickers)
+
+
+def rsi(series: pd.Series, window: int = 14) -> pd.Series:
+    delta = series.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    gain = up.rolling(window).mean()
+    loss = down.rolling(window).mean()
+    rs = gain / loss
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+
+def infer_release_time(ts: pd.Timestamp) -> str:
+    if ts is pd.NaT or ts.hour == 0 and ts.minute == 0:
+        return "intraday"
+    if ts.hour < 9 or (ts.hour == 9 and ts.minute < 30):
+        return "pre"
+    if ts.hour >= 16:
+        return "post"
+    return "intraday"
+
+
+def process_ticker(ticker: str, start: pd.Timestamp, end: pd.Timestamp) -> list:
+    tkr = yf.Ticker(ticker)
+    try:
+        cal = tkr.get_earnings_dates(limit=60)
+    except Exception:
+        return []
+    if cal is None or cal.empty:
+        return []
+    cal = cal[(cal.index >= start) & (cal.index <= end)]
+    if cal.empty:
+        return []
+    try:
+        info = tkr.get_info()
+    except Exception:
+        info = {}
+    try:
+        hist = tkr.history(start=start - timedelta(days=40), end=end + timedelta(days=5))
+    except Exception:
+        return []
+    if hist.empty:
+        return []
+    dollar_vol = (hist["Close"] * hist["Volume"]).median()
+    if dollar_vol < 10_000_000:
+        return []
+    earnings = tkr.get_earnings()
+    rows = []
+    for dt, row in cal.iterrows():
+        prev_prices = hist[:dt - timedelta(days=1)]
+        if len(prev_prices) < 21:
+            continue
+        future_prices = hist[dt: dt + timedelta(days=2)]
+        if len(future_prices) < 3:
+            continue
+        close_pre = prev_prices["Close"].iloc[-1]
+        close_plus2 = future_prices["Close"].iloc[2]
+        label = int((close_plus2 - close_pre) / close_pre >= 0.05)
+        prev_5d_ret = (prev_prices["Close"].iloc[-1] - prev_prices["Close"].iloc[-5]) / prev_prices["Close"].iloc[-5]
+        prev_10d_vol = np.log(prev_prices["Close"]).diff().iloc[-10:].std()
+        sma20 = prev_prices["Close"].rolling(20).mean().iloc[-1]
+        sma20_gap = (prev_prices["Close"].iloc[-1] - sma20) / sma20
+        rsi14 = rsi(prev_prices["Close"]).iloc[-1]
+        eps_est = row.get("epsestimate") or row.get("EPS Estimate") or np.nan
+        revenue_est = row.get("revenueestimate") or row.get("Revenue Estimate") or np.nan
+        release_time = infer_release_time(dt)
+        prev_eps = np.nan
+        if earnings is not None and not earnings.empty:
+            prev_eps = earnings.iloc[-1]["Earnings"]
+        rows.append({
+            "ticker": ticker,
+            "event_date": dt.to_pydatetime(),
+            "release_time": release_time,
+            "sector": info.get("sector"),
+            "industry": info.get("industry"),
+            "mkt_cap": info.get("marketCap", np.nan) / 1e6 if info.get("marketCap") else np.nan,
+            "pe_ratio": info.get("trailingPE", np.nan),
+            "beta": info.get("beta", np.nan),
+            "prev_qtr_eps": prev_eps,
+            "eps_est": eps_est,
+            "revenue_est": revenue_est,
+            "prev_5d_ret": prev_5d_ret,
+            "prev_10d_vol": prev_10d_vol,
+            "sma20_gap": sma20_gap,
+            "rsi14": rsi14,
+            "short_int_ratio": (info.get("sharesShort") or 0) / info.get("floatShares", np.nan) if info.get("floatShares") else np.nan,
+            "label": label,
+        })
+    return rows
+
+
+def build_dataset(start: str, end: str) -> Path:
+    start_dt = pd.to_datetime(start)
+    end_dt = pd.to_datetime(end)
+    tmp_dir = Path("data/parquet")
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    universe = get_universe()
+    all_rows = []
+    chunk_idx = 0
+    for ticker in tqdm(universe, desc="Tickers"):
+        rows = process_ticker(ticker, start_dt, end_dt)
+        if not rows:
+            continue
+        all_rows.extend(rows)
+        if len(all_rows) >= CHUNK_SIZE:
+            df = pd.DataFrame(all_rows)
+            chunk_file = tmp_dir / f"chunk_{chunk_idx}.parquet"
+            df.to_parquet(chunk_file, index=False)
+            all_rows = []
+            chunk_idx += 1
+    if all_rows:
+        df = pd.DataFrame(all_rows)
+        chunk_file = tmp_dir / f"chunk_{chunk_idx}.parquet"
+        df.to_parquet(chunk_file, index=False)
+    files = list(tmp_dir.glob("chunk_*.parquet"))
+    df_list = [pd.read_parquet(f) for f in files]
+    full = pd.concat(df_list, ignore_index=True)
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    full.to_parquet(OUT_PATH, index=False)
+    for f in files:
+        f.unlink()
+    return OUT_PATH
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if OUT_PATH.exists() and not args.force:
+        print(f"Dataset already exists at {OUT_PATH}")
+    else:
+        path = build_dataset(args.start, args.end)
+        print(f"Saved dataset to {path}")

--- a/features/feature_builder.py
+++ b/features/feature_builder.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+import joblib
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+
+NUM_COLS = [
+    "mkt_cap",
+    "pe_ratio",
+    "beta",
+    "prev_qtr_eps",
+    "eps_est",
+    "revenue_est",
+    "prev_5d_ret",
+    "prev_10d_vol",
+    "sma20_gap",
+    "rsi14",
+    "short_int_ratio",
+]
+CAT_COLS = ["sector", "industry", "release_time"]
+
+
+class FeatureBuilder:
+    def __init__(self):
+        self.quantiles = {}
+        self.medians = {}
+        self.means = {}
+        self.stds = {}
+        self.target_enc = {}
+
+    def fit(self, df: pd.DataFrame) -> None:
+        for c in NUM_COLS:
+            low = df[c].quantile(0.005)
+            high = df[c].quantile(0.995)
+            self.quantiles[c] = (low, high)
+            self.medians[c] = df[c].median()
+            self.means[c] = df[c].mean()
+            self.stds[c] = df[c].std() or 1.0
+        for c in CAT_COLS:
+            self.target_enc[c] = df.groupby(c)["label"].mean()
+
+    def transform(self, df: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series]:
+        out = df.copy()
+        for c in NUM_COLS:
+            low, high = self.quantiles[c]
+            out[c] = out[c].clip(low, high)
+            out[c] = out[c].fillna(self.medians[c])
+            out[c] = (out[c] - self.means[c]) / self.stds[c]
+        for c in CAT_COLS:
+            mapping = self.target_enc.get(c, {})
+            out[c] = out[c].map(mapping).fillna(mapping.mean() if len(mapping) else 0)
+        y = out.pop("label")
+        return out, y
+
+    def save(self, path: Path) -> None:
+        joblib.dump(self, path)
+
+    @staticmethod
+    def load(path: Path) -> "FeatureBuilder":
+        return joblib.load(path)

--- a/predict/predict_winners.py
+++ b/predict/predict_winners.py
@@ -1,0 +1,109 @@
+import argparse
+import json
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from rich.console import Console
+from rich.table import Table
+
+from features.feature_builder import FeatureBuilder
+from train.train_model import precision_at_k
+from catboost import CatBoostClassifier
+
+MODEL_PATH = Path("models/catboost_gpu.cbm")
+FB_PATH = Path("models/feature_builder.joblib")
+
+
+def load_calendar(path: Path) -> pd.DataFrame:
+    data = json.loads(Path(path).read_text())
+    rows = data.get("data", {}).get("rows", [])
+    df = pd.DataFrame(rows)
+    df = df[df.get("symbol").notna()]
+    df["symbol"] = df["symbol"].str.strip()
+    return df
+
+
+def map_time(value: str) -> str:
+    if value == "time-pre-market":
+        return "pre"
+    if value == "time-after-hours":
+        return "post"
+    return "intraday"
+
+
+def build_event_row(ticker: str, release_time: str) -> dict | None:
+    tkr = yf.Ticker(ticker)
+    try:
+        info = tkr.get_info()
+        hist = tkr.history(period="1mo")
+    except Exception:
+        return None
+    if hist.empty:
+        return None
+    prev_prices = hist.iloc[:-1]
+    if len(prev_prices) < 20:
+        return None
+    close_prev = prev_prices["Close"].iloc[-1]
+    prev_5d_ret = (prev_prices["Close"].iloc[-1] - prev_prices["Close"].iloc[-5]) / prev_prices["Close"].iloc[-5]
+    prev_10d_vol = np.log(prev_prices["Close"]).diff().iloc[-10:].std()
+    sma20 = prev_prices["Close"].rolling(20).mean().iloc[-1]
+    sma20_gap = (close_prev - sma20) / sma20
+    from earnings.build_dataset import rsi
+    rsi14 = rsi(prev_prices["Close"]).iloc[-1]
+    return {
+        "ticker": ticker,
+        "release_time": release_time,
+        "sector": info.get("sector"),
+        "industry": info.get("industry"),
+        "mkt_cap": info.get("marketCap", np.nan) / 1e6 if info.get("marketCap") else np.nan,
+        "pe_ratio": info.get("trailingPE", np.nan),
+        "beta": info.get("beta", np.nan),
+        "prev_qtr_eps": np.nan,
+        "eps_est": np.nan,
+        "revenue_est": np.nan,
+        "prev_5d_ret": prev_5d_ret,
+        "prev_10d_vol": prev_10d_vol,
+        "sma20_gap": sma20_gap,
+        "rsi14": rsi14,
+        "short_int_ratio": (info.get("sharesShort") or 0) / info.get("floatShares", np.nan) if info.get("floatShares") else np.nan,
+        "label": 0,
+    }
+
+
+def predict_winners(calendar_json: str, top: int) -> None:
+    fb = FeatureBuilder.load(FB_PATH)
+    model = CatBoostClassifier()
+    model.load_model(MODEL_PATH)
+    cal_df = load_calendar(calendar_json)
+    events = []
+    for _, row in cal_df.iterrows():
+        ticker = row["symbol"].strip()
+        release_time = map_time(row.get("time", ""))
+        data = build_event_row(ticker, release_time)
+        if data:
+            events.append(data)
+    if not events:
+        print("No events to score")
+        return
+    df = pd.DataFrame(events)
+    X, _ = fb.transform(df)
+    probs = model.predict_proba(X)[:, 1]
+    df["prob_1"] = probs
+    df = df.sort_values("prob_1", ascending=False).head(top)
+
+    table = Table(title="Top Earnings Winners")
+    for col in ["ticker", "prob_1", "eps_est", "prev_5d_ret"]:
+        table.add_column(col)
+    for _, r in df.iterrows():
+        table.add_row(r["ticker"], f"{r['prob_1']:.3f}", str(r.get("eps_est", "")), f"{r['prev_5d_ret']:.2%}")
+    Console().print(table)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--calendar_json", required=True)
+    parser.add_argument("--model", default=str(MODEL_PATH))
+    parser.add_argument("--top", type=int, default=3)
+    args = parser.parse_args()
+    predict_winners(args.calendar_json, args.top)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
-finance_calendars
+catboost==1.2.5
+yfinance==0.2.40
+pandas
+numpy
+rich
+tqdm
+joblib
 requests
-yfinance
+pyarrow
+finance_calendars

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,28 @@
+import argparse
+from pathlib import Path
+
+from earnings.build_dataset import build_dataset, OUT_PATH as DATA_PATH
+from train.train_model import train_model
+from predict.predict_winners import predict_winners
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run earnings winner pipeline")
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--calendar_json", required=True)
+    parser.add_argument("--top", type=int, default=5)
+    parser.add_argument("--retrain", action="store_true")
+    args = parser.parse_args()
+
+    if not DATA_PATH.exists():
+        build_dataset(args.start, args.end)
+    else:
+        if args.retrain:
+            build_dataset(args.start, args.end)
+
+    model_path = Path("models/catboost_gpu.cbm")
+    if not model_path.exists() or args.retrain:
+        train_model()
+
+    predict_winners(args.calendar_json, args.top)

--- a/train/train_model.py
+++ b/train/train_model.py
@@ -1,0 +1,70 @@
+import pandas as pd
+from pathlib import Path
+from catboost import CatBoostClassifier, Pool
+from sklearn.metrics import roc_auc_score, accuracy_score
+from sklearn.model_selection import TimeSeriesSplit
+import numpy as np
+from features.feature_builder import FeatureBuilder
+
+DATA_PATH = Path("data/earnings_dataset.parquet")
+MODEL_PATH = Path("models/catboost_gpu.cbm")
+FB_PATH = Path("models/feature_builder.joblib")
+
+PARAMS = dict(
+    depth=8,
+    learning_rate=0.05,
+    iterations=2000,
+    l2_leaf_reg=3,
+    random_strength=1,
+    loss_function="Logloss",
+    task_type="GPU",
+    devices="0",
+    early_stopping_rounds=200,
+    verbose=100,
+    random_seed=42,
+)
+
+
+def precision_at_k(y_true, y_prob, pct=0.05):
+    k = max(1, int(len(y_prob) * pct))
+    top_idx = np.argsort(y_prob)[-k:][::-1]
+    return (y_true.iloc[top_idx] == 1).mean()
+
+
+def train_model() -> None:
+    df = pd.read_parquet(DATA_PATH).sort_values("event_date")
+    fb = FeatureBuilder()
+    fb.fit(df)
+    X, y = fb.transform(df)
+    split_date = df["event_date"].max() - pd.DateOffset(months=18)
+    train_idx = df["event_date"] < split_date
+    test_idx = df["event_date"] >= split_date
+    X_train, y_train = X.loc[train_idx], y.loc[train_idx]
+    X_test, y_test = X.loc[test_idx], y.loc[test_idx]
+    tscv = TimeSeriesSplit(n_splits=5)
+    best_iter = PARAMS["iterations"]
+    for tr, val in tscv.split(X_train):
+        tr_pool = Pool(X_train.iloc[tr], y_train.iloc[tr])
+        val_pool = Pool(X_train.iloc[val], y_train.iloc[val])
+        model = CatBoostClassifier(**PARAMS)
+        model.fit(tr_pool, eval_set=val_pool)
+        best_iter = model.get_best_iteration()
+    final_model = CatBoostClassifier(**{**PARAMS, "iterations": best_iter})
+    final_model.fit(Pool(X_train, y_train))
+    fb.save(FB_PATH)
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    final_model.save_model(MODEL_PATH)
+
+    prob_tr = final_model.predict_proba(X_train)[:, 1]
+    prob_te = final_model.predict_proba(X_test)[:, 1]
+    metrics = pd.DataFrame({
+        "AUROC": [roc_auc_score(y_train, prob_tr), roc_auc_score(y_test, prob_te)],
+        "Acc": [accuracy_score(y_train, prob_tr > 0.5), accuracy_score(y_test, prob_te > 0.5)],
+        "P@Top1": [precision_at_k(y_train, prob_tr, 0.01), precision_at_k(y_test, prob_te, 0.01)],
+        "P@Top5": [precision_at_k(y_train, prob_tr, 0.05), precision_at_k(y_test, prob_te, 0.05)],
+    }, index=["Train", "Test"])
+    print(metrics)
+
+
+if __name__ == "__main__":
+    train_model()


### PR DESCRIPTION
## Summary
- implement dataset builder under `earnings/`
- add feature builder with scaling and target encoding
- train CatBoost GPU model with time-series CV
- predict next-day winners from Nasdaq JSON
- orchestrate full workflow via `run_pipeline.py`
- document usage in README and list new dependencies

## Testing
- `python -m compileall -q earnings features train predict run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6847853236888323b86dbac97e5788b6