### PR TITLE
Fix universe retrieval

### DIFF
--- a/earnings/build_dataset.py
+++ b/earnings/build_dataset.py
@@ -19,9 +19,35 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def get_universe() -> list:
-    tickers = set(yf.tickers_sp500() + yf.tickers_sp400() + yf.tickers_sp600())
-    return sorted(tickers)
+import functools, pathlib, pickle, time, pandas as pd, requests
+
+_UNIVERSE_CACHE = pathlib.Path("data/universe_cache.pkl")
+
+@functools.lru_cache(maxsize=1)
+def _scrape_wiki(url: str, col: str) -> list[str]:
+    """Return the ticker column from the first HTML table on the page."""
+    html = requests.get(url, timeout=15).text
+    return pd.read_html(html)[0][col].str.strip().tolist()
+
+def get_universe() -> list[str]:
+    """
+    Union of S&P 500 / 400 / 600 tickers, scraped from Wikipedia and
+    cached on disk for 24 h to avoid repeated HTTP traffic.
+    """
+    if _UNIVERSE_CACHE.exists() and time.time() - _UNIVERSE_CACHE.stat().st_mtime < 86_400:
+        return pickle.loads(_UNIVERSE_CACHE.read_bytes())
+
+    sp500 = _scrape_wiki("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies",
+                         "Symbol")
+    sp400 = _scrape_wiki("https://en.wikipedia.org/wiki/List_of_S%26P_400_companies",
+                         "Ticker symbol")
+    sp600 = _scrape_wiki("https://en.wikipedia.org/wiki/List_of_S%26P_600_companies",
+                         "Ticker symbol")
+
+    universe = sorted({*sp500, *sp400, *sp600})
+    _UNIVERSE_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    _UNIVERSE_CACHE.write_bytes(pickle.dumps(universe))
+    return universe
 
 
 def rsi(series: pd.Series, window: int = 14) -> pd.Series:


### PR DESCRIPTION
## Summary
- patch `get_universe()` in earnings pipeline to avoid deprecated `yfinance` helpers

## Testing
- `python -m py_compile earnings/build_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68478ad7c6d88323832c54dbd309ef99