### PR TITLE
Fix missing sklearn dependency and update ticker scraping

### DIFF
--- a/earnings/build_dataset.py
+++ b/earnings/build_dataset.py
@@ -43,11 +43,11 @@ def get_universe() -> list[str]:
     )
     sp400 = _scrape_wiki(
         "https://en.wikipedia.org/wiki/List_of_S%26P_400_companies",
-        "Ticker symbol",
+        "Symbol",
     )
     sp600 = _scrape_wiki(
         "https://en.wikipedia.org/wiki/List_of_S%26P_600_companies",
-        "Ticker symbol",
+        "Symbol",
     )
 
     universe = sorted({*sp500, *sp400, *sp600})

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ joblib
 requests
 pyarrow
 finance_calendars
+scikit-learn


### PR DESCRIPTION
## Summary
- include scikit-learn in requirements
- update wiki scraping for S&P 400/600 tickers to match current column names

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py --start 2018-01-01 --end 2025-05-31 --calendar_json data/raw/calendar_20250611.json --top 5 --retrain` *(interrupted after starting)*

------
https://chatgpt.com/codex/tasks/task_e_68478f8a153883239c61ec1fd9c7aec6